### PR TITLE
Bugfix hide forms & show answers

### DIFF
--- a/assets/scripts/survey/surveyEvents.js
+++ b/assets/scripts/survey/surveyEvents.js
@@ -23,6 +23,7 @@ const onCreateSurvey = (event) => {
 
 const onShowSurveys = (event) => {
   event.preventDefault()
+  $('#answerStats').hide()
 
   api.showAllSurveys()
     .then(ui.onGetAllSurveysSuccess)
@@ -57,6 +58,7 @@ const onUpdateSurvey = (event) => {
   event.stopPropagation()
   store.SurveyId = id // saving id of the element in the list (survey) that was clicked
   $('#oneSurvey').hide()
+  $('#answerStats').hide()
   $('#updateSurvey').show()
   $('#createSurvey').hide()
 }
@@ -80,6 +82,8 @@ const onEditSurvey = (event) => {
 
 const onDeleteSurvey = (event) => {
   event.preventDefault()
+  $('#answerStats').hide()
+  $('#oneSurvey').hide()
   const id = $(event.target).closest('section').data('id')
   // console.log(id)
   event.stopPropagation()
@@ -89,6 +93,7 @@ const onDeleteSurvey = (event) => {
     .catch(ui.onDeleteSurveyFailure)
 }
 const showCreateSurveyForm = (event) => {
+  $('#answerStats').hide()
   $('#oneSurvey').hide()
   $('#updateSurvey').hide()
   $('#surveybox').show()

--- a/assets/scripts/survey/ui.js
+++ b/assets/scripts/survey/ui.js
@@ -43,17 +43,20 @@ const onGetOneSurveySuccess = (response) => {
 }
 
 const showSurveyAnswers = (response) => {
+  // console.log(store.survey._id)
   $('.answer1').text(' ')
   $('.answer2').text(' ')
   $('.answer3').text(' ')
   $('.answer4').text(' ')
   store.answersArray = response.answers
+  const filterAnswers = store.answersArray.filter(answer => answer.surveyRef === store.survey._id)
+  // console.log(filterAnswers)
   const possibleAnswers = []
   store.survey.possibleAnswers.forEach(answer => {
     possibleAnswers.push(answer)
   })
   const answerArray = []
-  store.answersArray.forEach(answer => {
+  filterAnswers.forEach(answer => {
     answerArray.push(answer)
   })
   const allAnswers = []

--- a/assets/scripts/survey/ui.js
+++ b/assets/scripts/survey/ui.js
@@ -8,6 +8,7 @@ const onCreateSuccess = function (response) {
   $('#message').show('')
   $('#message').text('Success!')
   $('#message').delay(2000).hide('Success!')
+  $('#createSurvey').hide()
   $('#createSurvey').trigger('reset')
 }
 
@@ -121,6 +122,7 @@ const sendSurveyFailure = () => {
 }
 
 const onDeleteSurveySuccess = () => {
+  $('#answerStats').hide()
   $('#message').show('')
   $('#message').text('Survey deleted.')
   $('#message').delay(2000).hide('Survey deleted.')


### PR DESCRIPTION
Fixed an error where get answers was displaying all answers (from other surveys if the answers matched exactly) in total counts, not just for the displayed survey. The answers html field is now hidden after other events happen, such as update and delete.